### PR TITLE
Throttle Play in-app review after saves and shares

### DIFF
--- a/app/src/main/java/com/chunkymonkey/pgntogifconverter/review/InAppReviewPromptController.kt
+++ b/app/src/main/java/com/chunkymonkey/pgntogifconverter/review/InAppReviewPromptController.kt
@@ -1,0 +1,41 @@
+package com.chunkymonkey.pgntogifconverter.review
+
+import com.chunkymonkey.pgntogifconverter.preference.PreferenceService
+
+/**
+ * Persists engagement counters and cooldown for in-app review prompts.
+ */
+class InAppReviewPromptController(
+    private val preferenceService: PreferenceService,
+) {
+
+    fun recordValuableAction() {
+        val c = preferenceService.getInt(KEY_VALUABLE_ACTIONS, 0)
+        if (c < Int.MAX_VALUE) {
+            preferenceService.saveData(KEY_VALUABLE_ACTIONS, c + 1)
+        }
+    }
+
+    fun shouldOfferReview(nowEpochMs: Long): Boolean {
+        val state = InAppReviewPromptState(
+            valuableActionCount = preferenceService.getInt(KEY_VALUABLE_ACTIONS, 0),
+            lastPromptEpochMs = preferenceService.getLong(KEY_LAST_PROMPT_MS, 0L),
+            reviewPromptAttemptCount = preferenceService.getInt(KEY_PROMPT_ATTEMPTS, 0),
+        )
+        return InAppReviewPromptRules.shouldOffer(state, nowEpochMs)
+    }
+
+    fun markReviewFlowLaunched(nowEpochMs: Long) {
+        preferenceService.saveData(KEY_LAST_PROMPT_MS, nowEpochMs)
+        val attempts = preferenceService.getInt(KEY_PROMPT_ATTEMPTS, 0)
+        if (attempts < Int.MAX_VALUE) {
+            preferenceService.saveData(KEY_PROMPT_ATTEMPTS, attempts + 1)
+        }
+    }
+
+    companion object {
+        internal const val KEY_VALUABLE_ACTIONS = "in_app_review_valuable_actions"
+        internal const val KEY_LAST_PROMPT_MS = "in_app_review_last_prompt_ms"
+        internal const val KEY_PROMPT_ATTEMPTS = "in_app_review_prompt_attempts"
+    }
+}

--- a/app/src/main/java/com/chunkymonkey/pgntogifconverter/review/InAppReviewPromptRules.kt
+++ b/app/src/main/java/com/chunkymonkey/pgntogifconverter/review/InAppReviewPromptRules.kt
@@ -1,0 +1,25 @@
+package com.chunkymonkey.pgntogifconverter.review
+
+/**
+ * Pure rules for when to call the Play In-App Review API.
+ * Google may still choose not to show the dialog (quota, user history).
+ */
+data class InAppReviewPromptState(
+    val valuableActionCount: Int = 0,
+    val lastPromptEpochMs: Long = 0L,
+    val reviewPromptAttemptCount: Int = 0,
+)
+
+object InAppReviewPromptRules {
+
+    const val MIN_VALUABLE_ACTIONS: Int = 3
+    const val COOLDOWN_MS: Long = 30L * 24 * 60 * 60 * 1000
+    const val MAX_PROMPT_ATTEMPTS: Int = 5
+
+    fun shouldOffer(state: InAppReviewPromptState, nowEpochMs: Long): Boolean {
+        if (state.valuableActionCount < MIN_VALUABLE_ACTIONS) return false
+        if (state.reviewPromptAttemptCount >= MAX_PROMPT_ATTEMPTS) return false
+        if (state.lastPromptEpochMs == 0L) return true
+        return nowEpochMs - state.lastPromptEpochMs >= COOLDOWN_MS
+    }
+}

--- a/app/src/main/java/com/chunkymonkey/pgntogifconverter/ui/Navigator.kt
+++ b/app/src/main/java/com/chunkymonkey/pgntogifconverter/ui/Navigator.kt
@@ -8,8 +8,9 @@ import java.io.File
 
 
 object DefaultNavigator {
-    fun shareCurrentGif(file: File, context: Context) {
-        val uri = file.getStrictModeUri(context) ?: return
+    /** @return true if the share sheet was started */
+    fun shareCurrentGif(file: File, context: Context): Boolean {
+        val uri = file.getStrictModeUri(context) ?: return false
         val shareIntent = Intent(Intent.ACTION_SEND).apply {
             type = "image/gif"
             putExtra(Intent.EXTRA_STREAM, uri)
@@ -20,10 +21,12 @@ object DefaultNavigator {
                 shareIntent, context.resources.getText(R.string.share)
             )
         )
+        return true
     }
 
-    fun shareMp4(file: File, context: Context) {
-        val uri = file.getStrictModeUri(context) ?: return
+    /** @return true if the share sheet was started */
+    fun shareMp4(file: File, context: Context): Boolean {
+        val uri = file.getStrictModeUri(context) ?: return false
         val shareIntent = Intent(Intent.ACTION_SEND).apply {
             type = "video/mp4"
             putExtra(Intent.EXTRA_STREAM, uri)
@@ -34,5 +37,6 @@ object DefaultNavigator {
                 shareIntent, context.resources.getText(R.string.share)
             )
         )
+        return true
     }
 }

--- a/app/src/main/java/com/chunkymonkey/pgntogifconverter/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/chunkymonkey/pgntogifconverter/ui/home/HomeActivity.kt
@@ -32,6 +32,7 @@ import com.chunkymonkey.pgntogifconverter.data.RecentGamesStorage
 import com.chunkymonkey.pgntogifconverter.data.SettingsStorage
 import com.chunkymonkey.pgntogifconverter.dependency.DependencyFactory
 import com.chunkymonkey.pgntogifconverter.preference.PreferenceService
+import com.chunkymonkey.pgntogifconverter.review.InAppReviewPromptController
 import com.chunkymonkey.pgntogifconverter.ui.DefaultNavigator
 import com.chunkymonkey.pgntogifconverter.ui.error.ApplicationStringProvider
 import com.chunkymonkey.pgntogifconverter.ui.error.ApplicationStringProviderImpl
@@ -71,6 +72,9 @@ class HomeActivity : AppCompatActivity(), HomeView {
         )
     }
     private val reviewManager by lazy { ReviewManagerFactory.create(this.applicationContext) }
+    private val inAppReviewPromptController by lazy {
+        InAppReviewPromptController(PreferenceService(applicationContext))
+    }
     private val recentGamesStorage: RecentGamesStorage by lazy {
         RecentGamesStorage(PreferenceService(this.applicationContext))
     }
@@ -210,7 +214,6 @@ class HomeActivity : AppCompatActivity(), HomeView {
         }
 
         handleFromSystemIntent()
-        requestInAppReview()
         checkClipboardForPgn()
     }
 
@@ -320,6 +323,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
                 }
             }
             errorMessageHandler.showError(getString(R.string.gif_saved))
+            onValuableActionCompleted()
         } catch (e: Exception) {
             ErrorHandler.logException(e)
             errorMessageHandler.showError(getString(R.string.gif_save_failed))
@@ -335,6 +339,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
                 }
             }
             errorMessageHandler.showError(getString(R.string.mp4_saved))
+            onValuableActionCompleted()
         } catch (e: Exception) {
             ErrorHandler.logException(e)
             errorMessageHandler.showError(getString(R.string.mp4_save_failed))
@@ -344,12 +349,16 @@ class HomeActivity : AppCompatActivity(), HomeView {
     // --- HomeView implementation ---
 
     override fun shareCurrentGif(file: File) {
-        DefaultNavigator.shareCurrentGif(file, this)
+        if (DefaultNavigator.shareCurrentGif(file, this)) {
+            onValuableActionCompleted()
+        }
     }
 
     override fun shareMp4(file: File) {
         mp4File = file
-        DefaultNavigator.shareMp4(file, this)
+        if (DefaultNavigator.shareMp4(file, this)) {
+            onValuableActionCompleted()
+        }
     }
 
     override fun setPgnText(text: String) {
@@ -437,20 +446,28 @@ class HomeActivity : AppCompatActivity(), HomeView {
         getContent.launch(filePickerIntent)
     }
 
-    // --- In-app review ---
+    // --- In-app review (Play In-App Review API; throttled after saves/shares) ---
 
-    private fun requestInAppReview() {
+    private fun onValuableActionCompleted() {
         if (TestProcess.isInstrumentedTest()) return
+        inAppReviewPromptController.recordValuableAction()
+        maybeRequestInAppReview()
+    }
+
+    private fun maybeRequestInAppReview() {
+        if (TestProcess.isInstrumentedTest()) return
+        if (!inAppReviewPromptController.shouldOfferReview(System.currentTimeMillis())) return
         val request = reviewManager.requestReviewFlow()
         request.addOnCompleteListener { task ->
             if (task.isSuccessful) {
+                inAppReviewPromptController.markReviewFlowLaunched(System.currentTimeMillis())
                 reviewManager.launchReviewFlow(this, task.result)
             } else {
-                task.exception?.let {
-                    ErrorHandler.logException(it)
-                    ErrorHandler.logInfo(
-                        "Review Task failed with code ${(task.exception as ReviewException).errorCode}"
-                    )
+                task.exception?.let { ex ->
+                    ErrorHandler.logException(ex)
+                    if (ex is ReviewException) {
+                        ErrorHandler.logInfo("Review Task failed with code ${ex.errorCode}")
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/example/pgntogifconverter/review/InAppReviewPromptRulesTest.kt
+++ b/app/src/test/java/com/example/pgntogifconverter/review/InAppReviewPromptRulesTest.kt
@@ -1,0 +1,60 @@
+package com.example.pgntogifconverter.review
+
+import com.chunkymonkey.pgntogifconverter.review.InAppReviewPromptRules
+import com.chunkymonkey.pgntogifconverter.review.InAppReviewPromptState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InAppReviewPromptRulesTest {
+
+    private val now = 1_000_000_000_000L
+
+    @Test
+    fun shouldOffer_insufficientActions_returnsFalse() {
+        val state = InAppReviewPromptState(valuableActionCount = 2, lastPromptEpochMs = 0L, reviewPromptAttemptCount = 0)
+        assertFalse(InAppReviewPromptRules.shouldOffer(state, now))
+    }
+
+    @Test
+    fun shouldOffer_minActionsNeverPrompted_returnsTrue() {
+        val state = InAppReviewPromptState(
+            valuableActionCount = InAppReviewPromptRules.MIN_VALUABLE_ACTIONS,
+            lastPromptEpochMs = 0L,
+            reviewPromptAttemptCount = 0,
+        )
+        assertTrue(InAppReviewPromptRules.shouldOffer(state, now))
+    }
+
+    @Test
+    fun shouldOffer_maxAttemptsReached_returnsFalse() {
+        val state = InAppReviewPromptState(
+            valuableActionCount = 10,
+            lastPromptEpochMs = 0L,
+            reviewPromptAttemptCount = InAppReviewPromptRules.MAX_PROMPT_ATTEMPTS,
+        )
+        assertFalse(InAppReviewPromptRules.shouldOffer(state, now))
+    }
+
+    @Test
+    fun shouldOffer_withinCooldown_returnsFalse() {
+        val last = now - InAppReviewPromptRules.COOLDOWN_MS + 1
+        val state = InAppReviewPromptState(
+            valuableActionCount = 5,
+            lastPromptEpochMs = last,
+            reviewPromptAttemptCount = 1,
+        )
+        assertFalse(InAppReviewPromptRules.shouldOffer(state, now))
+    }
+
+    @Test
+    fun shouldOffer_afterCooldown_returnsTrue() {
+        val last = now - InAppReviewPromptRules.COOLDOWN_MS
+        val state = InAppReviewPromptState(
+            valuableActionCount = 5,
+            lastPromptEpochMs = last,
+            reviewPromptAttemptCount = 1,
+        )
+        assertTrue(InAppReviewPromptRules.shouldOffer(state, now))
+    }
+}


### PR DESCRIPTION
## Summary
- Remove in-app review prompt on every `HomeActivity` launch (aligns with Play guidelines).
- Prompt only after **3+** successful saves/shares, with **30-day** cooldown and **max 5** attempts.
- Record review attempt only when `requestReviewFlow()` succeeds; safer `ReviewException` logging.
- `DefaultNavigator.share*` return `Boolean` so we only count engagement when the share sheet starts.

## Testing
- `./gradlew testDebugUnitTest` (includes `InAppReviewPromptRulesTest`).

Made with [Cursor](https://cursor.com)